### PR TITLE
Use React.FC and remove PropsWithChildren

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "next/babel",
     [
       "@babel/preset-env",
       {

--- a/components/Fundraising.tsx
+++ b/components/Fundraising.tsx
@@ -6,7 +6,7 @@ interface FundraisingProps {
   sponsors?: Array<SponsorDescription>;
 }
 
-const Fundraising: React.FunctionComponent<FundraisingProps> = (props) => {
+const Fundraising: React.FC<FundraisingProps> = (props) => {
   const sponsors = props.sponsors ? (
     <p>
       We would like to thank our sponsors that made this lesson possible:&nbsp;

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Head from "next/head";
 
-const Layout: React.FunctionComponent = ({ children }) => {
+const Layout: React.FC = ({ children }) => {
   return (
     <>
       <Head>

--- a/components/Lesson.tsx
+++ b/components/Lesson.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { NextSeo } from "next-seo";
 import { useDispatch, useSelector } from "react-redux";
 import { switchLessonPage } from "../playground/actions";
@@ -27,9 +27,7 @@ const scrollToElem = (elem) => {
   window.scrollTo({ top: getElemPosition(elem), behavior: "smooth" });
 };
 
-const Lesson: React.FunctionComponent<PropsWithChildren<LessonProps>> = (
-  props: PropsWithChildren<LessonProps>
-) => {
+const Lesson: React.FC<LessonProps> = (props) => {
   const dispatch = useDispatch();
   const [initialRender, setInitialRender] = useState(true);
   let currentPage = useSelector((state: any) =>

--- a/components/LessonHeader.tsx
+++ b/components/LessonHeader.tsx
@@ -9,9 +9,7 @@ export interface LessonHeaderProps {
   title: string;
 }
 
-const LessonHeader: React.FunctionComponent<LessonHeaderProps> = (
-  props: LessonHeaderProps
-) => {
+const LessonHeader: React.FC<LessonHeaderProps> = (props) => {
   return (
     <div id="module_header" className="row no-gutters">
       <div className="col-10 offset-1">

--- a/components/LessonTile.tsx
+++ b/components/LessonTile.tsx
@@ -1,6 +1,6 @@
 // Represents a single lesson in the module list.
 
-import React, { PropsWithChildren } from "react";
+import React from "react";
 
 export interface LessonTileProps {
   // Optional link to the lesson page.
@@ -14,11 +14,7 @@ export interface LessonTileProps {
   icon: string;
 }
 
-type ComponentProps = PropsWithChildren<LessonTileProps>;
-
-const LessonTile: React.FunctionComponent<ComponentProps> = (
-  props: ComponentProps
-) => {
+const LessonTile: React.FC<LessonTileProps> = (props) => {
   const isAvailable = !!props.href;
   let lessonTile = (
     <div className={"module_tile" + (!isAvailable ? " inactive_module" : "")}>

--- a/components/ModuleHeaderAnimation.tsx
+++ b/components/ModuleHeaderAnimation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import Zdog from "zdog";
 
 const TAU = Zdog.TAU;
@@ -233,7 +233,7 @@ function animate(state: State) {
   requestAnimationFrame(animate.bind(this, state));
 }
 
-const ModuleHeaderAnimation: React.FunctionComponent = () => {
+const ModuleHeaderAnimation: React.FC = () => {
   const state: React.MutableRefObject<State> = useRef({
     illo: null,
     pausing: false,

--- a/components/NoScriptBar.tsx
+++ b/components/NoScriptBar.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-const NoScriptBar: React.FunctionComponent = () => {
+const NoScriptBar: React.FC = () => {
   return (
     <noscript>
       <p>

--- a/components/Page.tsx
+++ b/components/Page.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 
 export interface PageProps {
   // Title of the page
@@ -7,9 +7,7 @@ export interface PageProps {
   isCurrent?: boolean;
 }
 
-const Page: React.FunctionComponent<PropsWithChildren<PageProps>> = (
-  props: PropsWithChildren<PageProps>
-) => {
+const Page: React.FC<PageProps> = (props) => {
   return (
     <div
       className={`row no-gutters lesson_text lesson_page ${

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 
 export interface ProgressBarProps {
   onSwitchPage?: CallableFunction;
@@ -13,9 +13,7 @@ export interface ProgressPageProps {
   onClick?: CallableFunction;
 }
 
-export const ProgressPage: React.FunctionComponent<PropsWithChildren<
-  ProgressPageProps
->> = (props: PropsWithChildren<ProgressPageProps>) => {
+export const ProgressPage: React.FC<ProgressPageProps> = (props) => {
   const classes = [];
   props.active && classes.push("is_active");
   props.completed && classes.push("is_complete");
@@ -32,9 +30,7 @@ export const ProgressPage: React.FunctionComponent<PropsWithChildren<
   );
 };
 
-export const ProgressBar: React.FunctionComponent<PropsWithChildren<
-  ProgressBarProps
->> = (props: PropsWithChildren<ProgressBarProps>) => {
+export const ProgressBar: React.FC<ProgressBarProps> = (props) => {
   const onClick = (elem) => {
     // Switch page
     const pageNum = elem.target.attributes["data-step"].value;

--- a/components/SinglePageLesson.tsx
+++ b/components/SinglePageLesson.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { NextSeo } from "next-seo";
 
 import Fundraising from "./Fundraising";
@@ -17,9 +17,7 @@ export interface LessonProps {
   sponsors?: Array<string | Array<any>>;
 }
 
-const SinglePageLesson: React.FunctionComponent<PropsWithChildren<
-  LessonProps
->> = (props: PropsWithChildren<LessonProps>) => {
+const SinglePageLesson: React.FC<LessonProps> = (props) => {
   return (
     <>
       <NextSeo title={props.pageTitle + " - Low-Level Academy"} />

--- a/components/Tests.tsx
+++ b/components/Tests.tsx
@@ -25,7 +25,7 @@ interface TestProps {
     children?: any
 }
 
-export const Test: React.FunctionComponent<TestProps> = (props) => {
+export const Test: React.FC<TestProps> = (props) => {
     const icon =
         props.state == TestState.Completed ?
             <TestCheckmark color="#39be78" /> :

--- a/components/lesson1/DnsRequestForm.tsx
+++ b/components/lesson1/DnsRequestForm.tsx
@@ -24,7 +24,7 @@ const scrollToElem = (elem) => {
   window.scrollTo({ top: getElemPosition(elem), behavior: "smooth" });
 };
 
-const DnsRequestForm: React.FunctionComponent = () => {
+const DnsRequestForm: React.FC = () => {
   const dispatch = useDispatch();
   const resolvedIp = useSelector(
     (state: any) => selectCompileResults(state, "fullDemo")?.resolvedIp

--- a/components/lesson1/FinalTestPlayground.tsx
+++ b/components/lesson1/FinalTestPlayground.tsx
@@ -29,7 +29,7 @@ interface OutputProps {
   visRef: React.RefObject<VNetInterface>;
 }
 
-const Output: React.FunctionComponent<OutputProps> = (props) => {
+const Output: React.FC<OutputProps> = (props) => {
   const somethingToShow = usePlaygroundSelector(selectors.getSomethingToShow);
   const formattedError = usePlaygroundSelector(selectors.formatError);
   const details = usePlaygroundSelector((state) => state.output.compile);
@@ -79,7 +79,7 @@ const Output: React.FunctionComponent<OutputProps> = (props) => {
   );
 };
 
-export const FinalTestVis: React.FunctionComponent = (props) => {
+export const FinalTestVis: React.FC = () => {
   const dispatch = useDispatch();
   const { playgroundId } = useContext(PlaygroundContext);
   const sentPackets = usePlaygroundSelector(

--- a/components/lesson1/FullDemoVis.tsx
+++ b/components/lesson1/FullDemoVis.tsx
@@ -26,7 +26,7 @@ interface OutputProps {
   visRef: React.RefObject<VNetInterface>;
 }
 
-const Output: React.FunctionComponent<OutputProps> = (props) => {
+const Output: React.FC<OutputProps> = (props) => {
   const somethingToShow = usePlaygroundSelector(selectors.getSomethingToShow);
   const formattedError = usePlaygroundSelector(selectors.formatError);
   const details = usePlaygroundSelector((state) => state.output.compile);
@@ -69,7 +69,7 @@ const Output: React.FunctionComponent<OutputProps> = (props) => {
   );
 };
 
-export const FullDemoVis: React.FunctionComponent = (props) => {
+export const FullDemoVis: React.FC = () => {
   const dispatch = useDispatch();
   const { playgroundId } = useContext(PlaygroundContext);
   const sentPackets = usePlaygroundSelector(

--- a/components/lesson1/IpPacketsVis.tsx
+++ b/components/lesson1/IpPacketsVis.tsx
@@ -41,9 +41,7 @@ export interface PacketTableVisProps {
   highlight?: (section: string) => any;
 }
 
-export const VisIpPacketHeader: React.FunctionComponent<PacketTableVisProps> = (
-  props
-) => {
+export const VisIpPacketHeader: React.FC<PacketTableVisProps> = (props) => {
   const highlight = props.highlight;
   const packet = props.packet;
   return (
@@ -118,9 +116,7 @@ export interface VisPacketHeaderProps {
   onHighlightSection: (section: string) => void;
 }
 
-export const VisPacketHeader: React.FunctionComponent<VisPacketHeaderProps> = (
-  props
-) => {
+export const VisPacketHeader: React.FC<VisPacketHeaderProps> = (props) => {
   const packet = props.packet;
 
   const highlight = useCallback(
@@ -159,7 +155,7 @@ export const VisPacketHeader: React.FunctionComponent<VisPacketHeaderProps> = (
   );
 };
 
-export const IpPacketsVis: React.FunctionComponent = (props) => {
+export const IpPacketsVis: React.FC = () => {
   const hexEditorRef: MutableRefObject<HexEditorHandle> = useRef();
   const dispatch = useDispatch();
   const { playgroundId } = useContext(PlaygroundContext);

--- a/components/lesson1/UdpDatagramVis.tsx
+++ b/components/lesson1/UdpDatagramVis.tsx
@@ -29,9 +29,7 @@ import { LOW_LVL_THEME } from "../network/ThemedHexViewer";
 import { evalUdpDatagramWasm } from "../../playground/lesson1/wasm";
 import { HexEditorHandle } from "react-hex-editor/dist/types";
 
-export const VisUdpPacketHeader: React.FunctionComponent<PacketTableVisProps> = (
-  props
-) => {
+export const VisUdpPacketHeader: React.FC<PacketTableVisProps> = (props) => {
   const highlight = props.highlight;
   const packet = props.packet;
   return (
@@ -72,7 +70,7 @@ export const VisUdpPacketHeader: React.FunctionComponent<PacketTableVisProps> = 
   );
 };
 
-export const UdpDatagramVis: React.FunctionComponent = (props) => {
+export const UdpDatagramVis: React.FC = () => {
   const hexEditorRef: MutableRefObject<HexEditorHandle> = useRef();
   const dispatch = useDispatch();
   const { playgroundId } = useContext(PlaygroundContext);

--- a/components/network/IcmpPacket.tsx
+++ b/components/network/IcmpPacket.tsx
@@ -4,9 +4,7 @@ import { convertIcmpTypeToStr } from "../../playground/reducers/virtualNetwork";
 import { NetworkPacketProps } from "./NetworkPacket";
 import { StyledTreeItem } from "./StyledTreeItem";
 
-export const IcmpPacket: React.FunctionComponent<NetworkPacketProps> = (
-  props
-) => {
+export const IcmpPacket: React.FC<NetworkPacketProps> = (props) => {
   const packet = props.packet;
   const num = props.num;
 

--- a/components/network/NetworkPacket.tsx
+++ b/components/network/NetworkPacket.tsx
@@ -17,9 +17,7 @@ export interface NetworkPacketProps {
   num: number;
 }
 
-export const NetworkPacket: React.FunctionComponent<NetworkPacketProps> = (
-  props
-) => {
+export const NetworkPacket: React.FC<NetworkPacketProps> = (props) => {
   const packet = props.packet;
   const num = props.num;
 

--- a/components/network/NetworkPacketsTree.tsx
+++ b/components/network/NetworkPacketsTree.tsx
@@ -35,9 +35,7 @@ export interface NetworkPacketsProps {
   packets: Array<Packet>;
 }
 
-export const NetworkPackets: React.FunctionComponent<NetworkPacketsProps> = (
-  props
-) => {
+export const NetworkPackets: React.FC<NetworkPacketsProps> = (props) => {
   const classes = useStyles();
 
   return (

--- a/components/network/NetworkPacketsViewer.tsx
+++ b/components/network/NetworkPacketsViewer.tsx
@@ -7,7 +7,7 @@ import { HexEditorHandle } from "react-hex-editor/dist/types";
 import { LOW_LVL_THEME } from "../../components/network/ThemedHexViewer";
 import { NetworkPackets } from "./NetworkPacketsTree";
 
-export const NetworkPacketsViewer: React.FunctionComponent<any> = (props) => {
+export const NetworkPacketsViewer: React.FC<any> = (props) => {
   const [selectedPacket, setSelectedPacket] = React.useState(0);
   const hexEditorRef: MutableRefObject<HexEditorHandle> = React.useRef();
 

--- a/components/network/StyledTreeItem.tsx
+++ b/components/network/StyledTreeItem.tsx
@@ -3,9 +3,7 @@ import TreeItem, { TreeItemProps } from "@material-ui/lab/TreeItem";
 
 import { useStyles } from "./NetworkPacketsTree";
 
-export const StyledTreeItem: React.FunctionComponent<TreeItemProps> = (
-  props
-) => {
+export const StyledTreeItem: React.FC<TreeItemProps> = (props) => {
   const classes = useStyles();
   return (
     <TreeItem

--- a/components/network/UdpPacket.tsx
+++ b/components/network/UdpPacket.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import { NetworkPacketProps } from "./NetworkPacket";
 import { StyledTreeItem } from "./StyledTreeItem";
 
-export const UdpPacket: React.FunctionComponent<NetworkPacketProps> = (
-  props
-) => {
+export const UdpPacket: React.FC<NetworkPacketProps> = (props) => {
   const packet = props.packet;
   const num = props.num;
 

--- a/components/prerequisites/number-encoding/index.tsx
+++ b/components/prerequisites/number-encoding/index.tsx
@@ -1,13 +1,13 @@
 // This module contains components that are used for representing numbers in different number systems.
 
-import React, { FunctionComponent, useState } from "react";
+import React, { useState } from "react";
 import styles from "./index.module.scss";
 
 interface NumberProps {
   className: string;
 }
 
-const Number: FunctionComponent<NumberProps> = (props) => (
+const Number: React.FC<NumberProps> = (props) => (
   <span className={props.className}>{props.children}</span>
 );
 

--- a/components/prerequisites/number-encoding/index.tsx
+++ b/components/prerequisites/number-encoding/index.tsx
@@ -3,14 +3,6 @@
 import React, { useState } from "react";
 import styles from "./index.module.scss";
 
-interface NumberProps {
-  className: string;
-}
-
-const Number: React.FC<NumberProps> = (props) => (
-  <span className={props.className}>{props.children}</span>
-);
-
 // Component that allows to input only numeric values.
 const NumericInput = (props) => (
   <input
@@ -31,7 +23,7 @@ const NumericInput = (props) => (
 
 // Represents a decimal number
 export const Dec = (props) => (
-  <Number className={styles.decimal}>{props.children}</Number>
+  <span className={styles.decimal}>{props.children}</span>
 );
 
 const DecInput = (props) => (
@@ -42,10 +34,10 @@ const DecInput = (props) => (
 
 // Represents a hex number
 export const Hex = (props) => (
-  <Number className={styles.hexadecimal}>
+  <span className={styles.hexadecimal}>
     {props.children}
     <sup>&nbsp;hex</sup>
-  </Number>
+  </span>
 );
 
 const HexInput = (props) => (
@@ -56,10 +48,10 @@ const HexInput = (props) => (
 
 // Represents an octal number
 export const Oct = (props) => (
-  <Number className={styles.octal}>
+  <span className={styles.octal}>
     {props.children}
     <sup>&nbsp;oct</sup>
-  </Number>
+  </span>
 );
 
 const OctInput = (props) => (
@@ -70,10 +62,10 @@ const OctInput = (props) => (
 
 // Represents a binary number
 export const Bin = (props) => (
-  <Number className={styles.binary}>
+  <span className={styles.binary}>
     {props.children}
     <sup>&nbsp;bin</sup>
-  </Number>
+  </span>
 );
 
 const BinInput = (props) => (

--- a/components/prerequisites/number-encoding/index.tsx
+++ b/components/prerequisites/number-encoding/index.tsx
@@ -7,9 +7,9 @@ interface NumberProps {
   className: string;
 }
 
-const Number: FunctionComponent<React.PropsWithChildren<NumberProps>> = (
-  props
-) => <span className={props.className}>{props.children}</span>;
+const Number: FunctionComponent<NumberProps> = (props) => (
+  <span className={props.className}>{props.children}</span>
+);
 
 // Component that allows to input only numeric values.
 const NumericInput = (props) => (
@@ -86,7 +86,7 @@ export interface UtfPlaygroundProps {
   base: number;
 }
 
-export const UtfPlayground: React.FunctionComponent<UtfPlaygroundProps> = (
+export const UtfPlayground: React.FC<UtfPlaygroundProps> = (
   props: UtfPlaygroundProps
 ) => {
   const [text, setText] = useState("abcdefg");
@@ -180,7 +180,7 @@ interface ExponentationProps {
   expDescription: Array<string>;
 }
 
-export const Exponentiation: React.FunctionComponent<ExponentationProps> = ({
+export const Exponentiation: React.FC<ExponentationProps> = ({
   exp,
   radix,
   expDescription,
@@ -213,7 +213,7 @@ export const Exponentiation: React.FunctionComponent<ExponentationProps> = ({
   );
 };
 
-export const BinaryPlayground: React.FunctionComponent = () => {
+export const BinaryPlayground: React.FC = () => {
   const [number, setNumber] = useState(11);
   const digits = [];
 
@@ -270,7 +270,7 @@ export const BinaryPlayground: React.FunctionComponent = () => {
   );
 };
 
-export const DecimalPlayground: React.FunctionComponent = (props) => {
+export const DecimalPlayground: React.FC = (props) => {
   const [number, setNumber] = useState(123);
   const digits = [];
 
@@ -330,7 +330,7 @@ export const DecimalPlayground: React.FunctionComponent = (props) => {
   );
 };
 
-export const OctalPlayground: React.FunctionComponent = () => {
+export const OctalPlayground: React.FC = () => {
   const [number, setNumber] = useState(0o777);
   const digits = [];
 
@@ -404,7 +404,7 @@ export const OctalPlayground: React.FunctionComponent = () => {
   );
 };
 
-export const HexPlayground: React.FunctionComponent = () => {
+export const HexPlayground: React.FC = () => {
   const [number, setNumber] = useState(0x1f);
   const digits = [];
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "low-level-academy",
   "version": "0.0.1",
   "dependencies": {
+    "@babel/preset-typescript": "^7.10.4",
     "@material-ui/core": "^5.0.0-alpha.10",
     "@material-ui/icons": "^5.0.0-alpha.7",
     "@material-ui/lab": "^5.0.0-alpha.10",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -89,7 +89,7 @@ interface OssProjectProps {
   title: string;
 }
 
-const OssProject = (props: PropsWithChildren<OssProjectProps>) => {
+const OssProject: React.FC<OssProjectProps> = (props) => {
   return (
     <div className="col-12 col-md-6 col-lg-4 col-xl-4">
       <div className="row">

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 
 const OSS_PROJECTS_LIST = [
   "facebook/react",

--- a/pages/prerequisites/binary-and-hexadecimal-numbers.tsx
+++ b/pages/prerequisites/binary-and-hexadecimal-numbers.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import SinglePageLesson from "../../components/SinglePageLesson";
 import BinariesAndHexadecimalsContent from "../../components/prerequisites/BinaryAndHexadecimal.mdx";
 
-const Content: React.FunctionComponent = () => {
+const Content: React.FC = () => {
   return (
     <SinglePageLesson
       module="Prerequisites"

--- a/pages/tcp-ip-fundamentals/exchanging-messages.tsx
+++ b/pages/tcp-ip-fundamentals/exchanging-messages.tsx
@@ -102,7 +102,7 @@ configureRustErrors({
   addImport: (playgroundId, code) => store.dispatch(addImport(code)),
 });
 
-const Lesson1: React.FunctionComponent = () => {
+const Lesson1: React.FC = () => {
   return (
     <Provider store={store}>
       <Lesson module="TCP/IP Fundamentals" badges={["Beginner", "Rust"]}>

--- a/playground/AdvancedEditor.tsx
+++ b/playground/AdvancedEditor.tsx
@@ -93,9 +93,7 @@ function useEditorProp<T>(
   }, [editor, prop, whenPresent]);
 }
 
-const AdvancedEditor: React.FunctionComponent<AdvancedEditorProps> = (
-  props
-) => {
+const AdvancedEditor: React.FC<AdvancedEditorProps> = (props) => {
   const [editor, setEditor] = useState<AceEditor>(null);
   const child = useRef<HTMLDivElement>(null);
 

--- a/playground/Editor.tsx
+++ b/playground/Editor.tsx
@@ -6,7 +6,7 @@ import AdvancedEditor from "./AdvancedEditor";
 
 import { PlaygroundContext, usePlaygroundSelector } from "./Playground";
 
-const Editor: React.FunctionComponent = () => {
+const Editor: React.FC = () => {
   const { playgroundId, codeWrapperFn } = useContext(PlaygroundContext);
   const code = usePlaygroundSelector((state) => state.code.current);
   const position = usePlaygroundSelector((state) => state.position);

--- a/playground/Header.tsx
+++ b/playground/Header.tsx
@@ -19,7 +19,7 @@ const BuildIcon = () => (
   </svg>
 );
 
-const Header: React.FunctionComponent = () => (
+const Header: React.FC = () => (
   <div className="header">
     <HeaderSet id="build">
       <SegmentedButtonSet>
@@ -34,12 +34,11 @@ interface HeaderSetProps {
   id: string;
 }
 
-const HeaderSet: React.FunctionComponent<HeaderSetProps> = ({
-  id,
-  children,
-}) => <div className={`header__set header__set--${id}`}>{children}</div>;
+const HeaderSet: React.FC<HeaderSetProps> = ({ id, children }) => (
+  <div className={`header__set header__set--${id}`}>{children}</div>
+);
 
-const ExecuteButton: React.FunctionComponent = () => {
+const ExecuteButton: React.FC = () => {
   const { playgroundId, codeWrapperFn } = useContext(PlaygroundContext);
   const dispatch = useDispatch();
   const execute = useCallback(
@@ -54,7 +53,7 @@ const ExecuteButton: React.FunctionComponent = () => {
   );
 };
 
-const ResetButton: React.FunctionComponent = () => {
+const ResetButton: React.FC = () => {
   const { playgroundId } = useContext(PlaygroundContext);
   const dispatch = useDispatch();
   const resetCode = useCallback(

--- a/playground/HeaderButton.tsx
+++ b/playground/HeaderButton.tsx
@@ -5,7 +5,7 @@ interface HeaderButtonProps {
   rightIcon?: React.ReactNode;
 }
 
-const HeaderButton: React.FunctionComponent<HeaderButtonProps> = ({
+const HeaderButton: React.FC<HeaderButtonProps> = ({
   icon,
   rightIcon,
   children,

--- a/playground/Output/Section.tsx
+++ b/playground/Output/Section.tsx
@@ -4,7 +4,7 @@ interface SectionProps {
   kind: string;
 }
 
-const Section: React.FunctionComponent<SectionProps> = ({ kind, children }) =>
+const Section: React.FC<SectionProps> = ({ kind, children }) =>
   children && (
     <div className={`output-${kind}`}>
       <pre>

--- a/playground/Output/SimplePane.tsx
+++ b/playground/Output/SimplePane.tsx
@@ -11,7 +11,7 @@ export interface ReallySimplePaneProps {
   error?: string;
 }
 
-const SimplePane: React.FunctionComponent<SimplePaneProps> = (props) => {
+const SimplePane: React.FC<SimplePaneProps> = (props) => {
   const { playgroundId } = useContext(PlaygroundContext);
   return (
     <div className={`output-${props.kind}`}>

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useContext } from "react";
+import React, { useContext } from "react";
 import { useSelector } from "react-redux";
 
 import Editor from "./Editor";
@@ -37,9 +37,7 @@ export interface PlaygroundProps {
   codeWrapperFn?: CodeWrapperFunction;
 }
 
-export const Playground: React.FunctionComponent<PropsWithChildren<
-  PlaygroundProps
->> = (props: PropsWithChildren<PlaygroundProps>) => {
+export const Playground: React.FC<PlaygroundProps> = (props) => {
   // We initialise a context with the given ID.
   // This context is used by all the child components and by created actions.
   const { id, codeWrapperFn } = props;

--- a/playground/SegmentedButton.tsx
+++ b/playground/SegmentedButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const SegmentedButtonSet: React.FunctionComponent = ({ children }) => (
+export const SegmentedButtonSet: React.FC = ({ children }) => (
   <div className="segmented-button">{children}</div>
 );
 


### PR DESCRIPTION
**This PR**
Closes https://github.com/LowLevelAcademy/LowLevelAcademy/issues/1 by
1. Changing all `React.FunctionComponent` to `React.FC`
2. Removing all unnecessary instances of `PropsWithChildren`
3. Removing some unneeded identifiers

I went with `React.FC` everywhere instead of `FC` everywhere because it seemed more consistent but would be happy to import `FC` from `React` in every file instead!