### PR TITLE
Corrected exponent in No500-in-decimal-explanation. Adjusted sentence…

### DIFF
--- a/components/prerequisites/BinaryAndHexadecimal.mdx
+++ b/components/prerequisites/BinaryAndHexadecimal.mdx
@@ -51,8 +51,7 @@ decimal numbers are not always practical when we deal with computers and data.
 Notice how we exponentiate the number <Dec>10</Dec>: it's our _number base_, or _radix_, which can be seen as the number of
 digits that we can use for counting, starting with zero. For example, base <Dec>10</Dec> has 10 digits from <Dec>0</Dec> to <Dec>9</Dec>,
 base <Dec>8</Dec> has 8 digits from <Oct>0</Oct> to <Oct>7</Oct>, and base <Dec>2</Dec> has only two digits: <Bin>0</Bin> and <Bin>1</Bin>. An exponent can also be seen as a digit's place.
-If we take a number like <Dec>500</Dec>, it has 3 digits: <Dec>5</Dec>, <Dec>0</Dec>, and <Dec>0</Dec>.<br/><Dec>5</Dec> is the _3<sup>rd</sup>_ digit from the right, so
-we take <Dec>10</Dec> to the power of <Dec>3</Dec> and multiply by the digit <Dec>5</Dec>, i.e.: <Dec>10<sup>2</sup></Dec> × <Dec>5</Dec> = <Dec>500</Dec>.
+If we take a number like <Dec>500</Dec>, it has 3 digits: <Dec>5</Dec>, <Dec>0</Dec>, and <Dec>0</Dec>.<br/><Dec>5</Dec> is the _3<sup>rd</sup>_ digit from the right. We can think of that row of numbers as a zero based list or array. Counting from the right, the <Dev>5</Dec> sits on index <Dec>2</Dec>. So we take <Dec>10</Dec> to the power of <Dec>2</Dec> and multiply by the digit <Dec>5</Dec>, i.e.: <Dec>10<sup>2</sup></Dec> × <Dec>5</Dec> = <Dec>500</Dec>.
 
 Something fun happens when we change the number base and follow the same principle of summing exponents.
 Let's see how it works in base `8`:


### PR DESCRIPTION
… to clarify how to count (indexing vs literal number-position)

In the prerequisites, the example of "how to calculate the digits in the number 500 in decimal", seems to have a typo.
It says that `5` is in position _3_ and therefore should be calculated as: `10^3 * 5`. Which I think results in `5000` and not in `500`.
- So I thought I change the exponent from `3` to `2`.
- And I've added/modified the sentence.  To explain that the position could be thought of as "zero-based indexing".

__Background__:
I have worked through your first chapters and find the site incredibly useful and hope that many others do as well. During that reading, I came across the minor "one-off-error" mentioned above.
In case I am actually wrong here, please forgive me.