### PR TITLE
Remove duplicate phrasing

### DIFF
--- a/components/prerequisites/number-encoding/index.tsx
+++ b/components/prerequisites/number-encoding/index.tsx
@@ -222,9 +222,7 @@ export const BinaryPlayground: React.FC = () => {
       <p>
         <span>
           The same thing happens if we use <Dec>2</Dec> as our number base. For
-          example, let&apos;s take the number&nbsp; Same thing happens if we use{" "}
-          <code>2</code> as our number base. For example, let&apos;s take a
-          number&nbsp;
+          example, let&apos;s take a number&nbsp;
         </span>
         <BinInput
           value={number.toString(2)}


### PR DESCRIPTION
Found your project today via lobster.rs, excellent idea! However, found a typo: the current version of the number-encoding tutorial text has a duplicated phrase with two different stylings; saved the one that seemed most consistent with the rest of the site.