### PR TITLE
Fix content errors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [nbaksalyar]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/components/prerequisites/number-encoding/index.tsx
+++ b/components/prerequisites/number-encoding/index.tsx
@@ -99,6 +99,9 @@ export const UtfPlayground: React.FC<UtfPlaygroundProps> = (
       break;
   }
 
+  const encoder = new TextEncoder();
+  const utf8 = encoder.encode(text);
+
   return (
     <form className={styles.utfPlayground}>
       <div className="form-group mr-3">
@@ -109,12 +112,7 @@ export const UtfPlayground: React.FC<UtfPlaygroundProps> = (
         />
       </div>
       <div className={styles.numbersEncoding}>
-        <Base>
-          {text
-            .split("")
-            .map((char) => char.charCodeAt(0).toString(props.base))
-            .join(" ")}
-        </Base>
+        <Base>{utf8.join(" ")}</Base>
       </div>
     </form>
   );


### PR DESCRIPTION
The playground incorrectly used Unicode code points instead of UTF-8 encoded bytes.

Thanks to @guepier for pointing this out.